### PR TITLE
Fix the scrollspy for external links

### DIFF
--- a/resources/script.js
+++ b/resources/script.js
@@ -2,7 +2,13 @@
 var offset = 50;
 
 $('.navbar li a.scroll').click(function(event) {
+	var href = $(this).attr('href');
+	
+	if (href.length === 0 || '#' !== href.charAt(0)) {
+		return;
+	}
+	
 	event.preventDefault();
-	$($(this).attr('href'))[0].scrollIntoView();
+	$(href)[0].scrollIntoView();
 	scrollBy(0, -offset);
 });


### PR DESCRIPTION
Closes #2

An alternative fix would be to use the `scroll` class only on anchor links
