### PR TITLE
Changed next release from 2016 to somewhere in the future

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 							<i class="fa fa-fw fa-download"></i>
 							<strong>ApiGen 4.2</strong>
 							<br>
-							<small>To be released in 2016.</small>
+							<small>To be released in the future.</small>
 						</a>
 					</p>
 				</div>


### PR DESCRIPTION
The release info for version 4.2 is still on 2016, so I have decided to change it from 'To be released in 2016' to 'To be released in the future' so that it does not look like the project is unmaintained.